### PR TITLE
Python import order fix

### DIFF
--- a/scripts/.flake8
+++ b/scripts/.flake8
@@ -3,7 +3,7 @@ max-line-length=120
 
 ignore=WPS, # TODO: Do not ignore WPS inspections
        D, # TODO: Do not ignore inspections related to documentation
-       I00, # TODO: Do not ignore inspections related to the order of imports
+       I00, # We use flake8-import-order (I1, I2) to sort the imports
        Q, # TODO: Do not ignore inspections related to quote checking
        W503, # Line break occurred before a binary operator. According to PEP8 the line break must come before the binary operator.
        RST301, # Unexpected indentation (in docstring).

--- a/scripts/analysis/call_expressions/python/call_expressions_analysis.py
+++ b/scripts/analysis/call_expressions/python/call_expressions_analysis.py
@@ -2,9 +2,9 @@ import argparse
 import logging
 from pathlib import Path
 
-import pandas as pd
-
 from call_expressions_column import CallExpressionsColumn
+
+import pandas as pd
 
 logging.basicConfig(level=logging.INFO)
 

--- a/scripts/analysis/clones/clones_features_builder.py
+++ b/scripts/analysis/clones/clones_features_builder.py
@@ -1,8 +1,10 @@
-import networkx as nx
-import pandas as pd
 from typing import Callable, Dict, List
 
 from column_names_utils import ClonesColumn, MethodsColumn
+
+import networkx as nx
+
+import pandas as pd
 
 
 class EdgeFilter:

--- a/scripts/analysis/clones/clones_graph_analysis.py
+++ b/scripts/analysis/clones/clones_graph_analysis.py
@@ -1,8 +1,10 @@
-from typing import List, Set, Tuple, Dict
-import networkx as nx
-import pandas as pd
+from typing import Dict, List, Set, Tuple
 
 from column_names_utils import ClonesColumn, MethodsColumn
+
+import networkx as nx
+
+import pandas as pd
 
 
 def add_edge(clones_graph: nx.Graph, row: pd.Series) -> Tuple[int, int, Dict]:

--- a/scripts/analysis/clones/code_features_utils.py
+++ b/scripts/analysis/clones/code_features_utils.py
@@ -1,11 +1,14 @@
 import os
-import pandas as pd
-from pygments import highlight
-from pygments.lexers import KotlinLexer
-from pygments.formatters import HtmlFormatter
 
 from column_names_utils import MethodsColumn
-from utils import get_file_lines
+
+import pandas as pd
+
+from pygments import highlight
+from pygments.formatters import HtmlFormatter
+from pygments.lexers import KotlinLexer
+
+from utils.file_utils import get_file_lines
 
 
 def add_code_features(df: pd.DataFrame, dataset_path: str):

--- a/scripts/analysis/clones/construct_dataframes.py
+++ b/scripts/analysis/clones/construct_dataframes.py
@@ -1,9 +1,12 @@
-import pandas as pd
 import os
-import networkx as nx
 
 from column_names_utils import ClonesColumn, MethodsColumn
-from utils import Extensions
+
+import networkx as nx
+
+import pandas as pd
+
+from utils.file_utils import Extensions
 
 
 def get_methods_df(folder: str) -> pd.DataFrame:

--- a/scripts/analysis/clones/construct_large_clones_dataframes.py
+++ b/scripts/analysis/clones/construct_large_clones_dataframes.py
@@ -1,9 +1,9 @@
-from typing import Tuple, Dict
-import pandas as pd
-
+from typing import Dict, Tuple
 
 # one pass over adjacency list to count all statistics
 from column_names_utils import MethodsColumn
+
+import pandas as pd
 
 
 def count_clones_statistics(file_path: str, min_projects: int = 10) -> Tuple[Dict, Dict]:

--- a/scripts/analysis/dependencies/fq_names_tree.py
+++ b/scripts/analysis/dependencies/fq_names_tree.py
@@ -6,8 +6,10 @@ from anytree import RenderTree
 from anytree.exporter import UniqueDotExporter
 
 from column_names_utils import ImportDirectivesColumn
+
 from fq_names_types import FqNamesDict
-from utils import Extensions, write_to_file, create_directory
+
+from utils.file_utils import Extensions, create_directory, write_to_file
 
 """
 Script fow working with import dependencies fq name tree.

--- a/scripts/analysis/dependencies/fq_names_types.py
+++ b/scripts/analysis/dependencies/fq_names_types.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Dict
+from typing import Dict, List, Union
 
 FqNamesDict = Dict[str, Union['FqNamesDict', int]]
 FqNamesStats = Dict[str, int]

--- a/scripts/analysis/dependencies/import_directives_analysis.py
+++ b/scripts/analysis/dependencies/import_directives_analysis.py
@@ -5,12 +5,16 @@ import sys
 from collections import Counter, defaultdict
 from typing import Callable, Dict, List, Set
 
+from column_names_utils import ImportDirectivesColumn
+
+from fq_names_tree import FqNameNode, build_fq_name_tree_decomposition, save_to_png, save_to_txt
+
+from fq_names_types import FqNamesDict, FqNamesGroups, FqNamesStats
+
 import pandas as pd
 
-from column_names_utils import ImportDirectivesColumn
-from fq_names_tree import FqNameNode, build_fq_name_tree_decomposition, save_to_png, save_to_txt
-from fq_names_types import FqNamesDict, FqNamesGroups, FqNamesStats
-from utils import Extensions, create_directory, get_file_lines
+from utils.file_utils import Extensions, create_directory, get_file_lines
+
 from visualization.diagram import show_bar_plot
 
 """

--- a/scripts/analysis/gradle_dependencies/gradle_dependencies_analysis.py
+++ b/scripts/analysis/gradle_dependencies/gradle_dependencies_analysis.py
@@ -2,16 +2,17 @@ import argparse
 import os
 import sys
 from collections import defaultdict
-from typing import Dict, List, Any
+from typing import Any, Dict, List
+
+from analysis.gradle_dependencies.column_names_utils import (
+    GradleDependenciesColumn,
+    GradleDependenciesConfigs,
+    GradleDependenciesStatsColumn,
+)
 
 import pandas as pd
 
-from analysis.gradle_dependencies.column_names_utils import (
-    GradleDependenciesStatsColumn,
-    GradleDependenciesColumn,
-    GradleDependenciesConfigs,
-)
-from utils import Extensions, create_directory
+from utils.file_utils import Extensions, create_directory
 
 GradleDependenciesStats = Dict[str, Any]
 

--- a/scripts/analysis/gradle_dependencies/gradle_dependencies_meta.py
+++ b/scripts/analysis/gradle_dependencies/gradle_dependencies_meta.py
@@ -4,12 +4,13 @@ import sys
 from collections import defaultdict
 from typing import Optional
 
-import pandas as pd
-
-from analysis.gradle_dependencies.column_names_utils import GradleDependenciesMetaColumn, GradleDependenciesColumn
+from analysis.gradle_dependencies.column_names_utils import GradleDependenciesColumn, GradleDependenciesMetaColumn
 from analysis.gradle_plugins.column_names_utils import GradlePluginsColumn
+
 from data_collection.github_data.api import get_repo
 from data_collection.package_search.api import get_packages
+
+import pandas as pd
 
 
 def url_to_repo_name(url: str) -> Optional[str]:

--- a/scripts/analysis/gradle_plugins/gradle_plugins_analysis.py
+++ b/scripts/analysis/gradle_plugins/gradle_plugins_analysis.py
@@ -1,13 +1,14 @@
 import argparse
 import os
-from collections import defaultdict
-
-import pandas as pd
 import sys
-from typing import Dict, Any
-from utils import Extensions, create_directory
+from collections import defaultdict
+from typing import Any, Dict
 
 from analysis.gradle_plugins.column_names_utils import GradlePluginsStatsColumn
+
+import pandas as pd
+
+from utils.file_utils import Extensions, create_directory
 
 GradlePluginsStats = Dict[str, Any]
 

--- a/scripts/analysis/gradle_properties/gradle_properties_analysis.py
+++ b/scripts/analysis/gradle_properties/gradle_properties_analysis.py
@@ -1,13 +1,15 @@
 import argparse
 import os
-from collections import defaultdict
-
-import pandas as pd
 import re
 import sys
-from analysis.gradle_properties.column_names_utils import GradlePropertiesKeyStatsColumn, GradlePropertiesColumn
-from typing import Dict, Any
-from utils import Extensions, create_directory, get_file_lines
+from collections import defaultdict
+from typing import Any, Dict
+
+from analysis.gradle_properties.column_names_utils import GradlePropertiesColumn, GradlePropertiesKeyStatsColumn
+
+import pandas as pd
+
+from utils.file_utils import Extensions, create_directory, get_file_lines
 
 GradlePropertiesStats = Dict[str, Any]
 

--- a/scripts/analysis/ranges/statistics_printer.py
+++ b/scripts/analysis/ranges/statistics_printer.py
@@ -1,5 +1,6 @@
-from collections import defaultdict
 import argparse
+from collections import defaultdict
+
 import pandas as pd
 
 TOTAL = "TOTAL"

--- a/scripts/data_collection/clean_duplicates.py
+++ b/scripts/data_collection/clean_duplicates.py
@@ -10,14 +10,16 @@ It accepts
     * index to start from (default 0)
 """
 
-import os
-import pandas as pd
 import argparse
 import logging
+import os
 from typing import Set, TextIO, Tuple
 
-from data_collection.data_collection_utils import save_repo_json, get_github_token, create_github_session
-from utils import create_directory, Extensions
+from data_collection.data_collection_utils import create_github_session, get_github_token, save_repo_json
+
+import pandas as pd
+
+from utils.file_utils import Extensions, create_directory
 
 
 def main():

--- a/scripts/data_collection/data_collection_utils.py
+++ b/scripts/data_collection/data_collection_utils.py
@@ -3,6 +3,7 @@ import os
 
 import requests
 from requests.adapters import HTTPAdapter
+
 from urllib3 import Retry
 
 

--- a/scripts/data_collection/db_connect.py
+++ b/scripts/data_collection/db_connect.py
@@ -1,7 +1,8 @@
 import logging
 from configparser import ConfigParser
 from pathlib import Path
-from typing import List, Tuple, Optional, Any, Dict
+from typing import Any, Dict, List, Optional, Tuple
+
 import psycopg2
 
 

--- a/scripts/data_collection/github_data/api.py
+++ b/scripts/data_collection/github_data/api.py
@@ -2,8 +2,9 @@ import os
 from typing import Optional
 
 from github import Github
-from requests.packages.urllib3.util.retry import Retry
 from github.Repository import Repository
+
+from requests.packages.urllib3.util.retry import Retry
 
 
 def get_github_token() -> str:

--- a/scripts/data_collection/load_dataset.py
+++ b/scripts/data_collection/load_dataset.py
@@ -6,18 +6,18 @@ It accepts
     * allowed extensions to filter, f.e. to save only .kt files
     * index to start from
 """
-import logging
-import shutil
-
-import pandas as pd
-import subprocess
 import argparse
+import logging
 import os
-
+import shutil
+import subprocess
 from typing import List
 
 from data_collection.filter_dataset import filter_files
-from utils import create_directory
+
+import pandas as pd
+
+from utils.file_utils import create_directory
 
 
 def load_dataset(input_path: str, output_path: str, allowed_extensions: List[str], start_from: int):

--- a/scripts/data_collection/package_search/api.py
+++ b/scripts/data_collection/package_search/api.py
@@ -1,10 +1,11 @@
 import json
 from typing import List
 
-import requests
 from dacite import from_dict
 
 from data_collection.package_search.model import Package, PackageSearchResponse
+
+import requests
 
 PACKAGE_SEARCH_API_BASE_URL = "https://package-search.services.jetbrains.com/api"
 PACKAGE_RANGE_REQUEST_DOMEN = "package?range="

--- a/scripts/data_collection/package_search/model.py
+++ b/scripts/data_collection/package_search/model.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Optional, List
+from typing import List, Optional
 
 
 @dataclass

--- a/scripts/data_collection/repositories_table.py
+++ b/scripts/data_collection/repositories_table.py
@@ -1,10 +1,11 @@
 import enum
 from datetime import datetime
-from psycopg2 import sql
-from psycopg2.sql import Identifier, Literal
-from typing import Tuple, List, Optional
+from typing import List, Optional, Tuple
 
 from data_collection.db_connect import DatabaseConn
+
+from psycopg2 import sql
+from psycopg2.sql import Identifier, Literal
 
 
 class RepositoriesTableNames(str, enum.Enum):

--- a/scripts/data_collection/save_github_daily.py
+++ b/scripts/data_collection/save_github_daily.py
@@ -5,20 +5,22 @@ It accepts
     * path to output directory
     * time to save GitHub at (optional argument)
 """
-import os
-import typing
-
-import pandas as pd
 import argparse
 import logging
-
-import requests
-import schedule
+import os
 import time
+import typing
 from datetime import datetime
 
-from utils.file_utils import create_directory, Extensions
-from data_collection.data_collection_utils import save_repo_json, get_github_token, create_github_session
+from data_collection.data_collection_utils import create_github_session, get_github_token, save_repo_json
+
+import pandas as pd
+
+import requests
+
+import schedule
+
+from utils.file_utils import Extensions, create_directory
 
 TIME = "17:00"
 

--- a/scripts/data_collection/save_metrics.py
+++ b/scripts/data_collection/save_metrics.py
@@ -6,18 +6,23 @@ It accepts
     * path to output directory
     * time to save GitHub at (optional argument)
 """
-import os
-import pandas as pd
 import argparse
 import logging
-from requests.packages.urllib3.util.retry import Retry
-import schedule
+import os
 import time
-from github import Github
 from datetime import datetime
 
-from utils import create_directory
 from data_collection.data_collection_utils import get_github_token
+
+from github import Github
+
+import pandas as pd
+
+from requests.packages.urllib3.util.retry import Retry
+
+import schedule
+
+from utils.file_utils import create_directory
 
 TIME = "01:00"
 

--- a/scripts/data_collection/update_dataset.py
+++ b/scripts/data_collection/update_dataset.py
@@ -10,17 +10,19 @@ Script accepts
     * index to start from
     * whether to use database or not
 """
+import argparse
 import datetime
 import logging
-from dataclasses import dataclass
-import pandas as pd
-import argparse
 import os
+from dataclasses import dataclass
 
 from data_collection.db_connect import DatabaseConn
-from data_collection.repositories_table import RepositoriesTable
 from data_collection.git_repo import GitRepository
-from utils import create_directory
+from data_collection.repositories_table import RepositoriesTable
+
+import pandas as pd
+
+from utils.file_utils import create_directory
 
 logging.basicConfig(level=logging.INFO)
 

--- a/scripts/plugin_runner/additional_arguments.py
+++ b/scripts/plugin_runner/additional_arguments.py
@@ -1,6 +1,5 @@
 import argparse
-
-from typing import List, Dict, Optional
+from typing import Dict, List, Optional
 
 
 class AdditionalArguments(argparse.Action):

--- a/scripts/plugin_runner/analyzers.py
+++ b/scripts/plugin_runner/analyzers.py
@@ -1,6 +1,5 @@
 from dataclasses import dataclass
 from enum import Enum
-
 from typing import List
 
 

--- a/scripts/plugin_runner/batch_processing.py
+++ b/scripts/plugin_runner/batch_processing.py
@@ -10,16 +10,18 @@ It accepts
 import argparse
 import logging
 import os
-from pathlib import Path
-from typing import List, Callable
 import time
+from pathlib import Path
+from typing import Callable, List
 
 from data_collection.db_connect import DatabaseConn
 from data_collection.repositories_table import RepositoriesTable
+
 from plugin_runner.additional_arguments import AdditionalArguments
-from plugin_runner.analyzers import Analyzer, AVAILABLE_ANALYZERS
+from plugin_runner.analyzers import AVAILABLE_ANALYZERS, Analyzer
 from plugin_runner.merge_data import merge
-from utils.file_utils import create_directory, get_subdirectories, Extensions, clear_directory
+
+from utils.file_utils import Extensions, clear_directory, create_directory, get_subdirectories
 from utils.run_process_utils import run_in_subprocess
 
 PROJECT_DIR = Path(__file__).parent.parent.parent

--- a/scripts/plugin_runner/create_venv.py
+++ b/scripts/plugin_runner/create_venv.py
@@ -27,9 +27,11 @@ from distutils.version import Version
 from pathlib import Path
 from typing import Dict, Optional, Set, Tuple
 
-import requests
 from pkg_resources import parse_requirements as parse_line, parse_version
+
+import requests
 from requests.adapters import HTTPAdapter
+
 from urllib3 import Retry
 
 from utils.file_utils import get_all_file_system_items

--- a/scripts/plugin_runner/merge_data.py
+++ b/scripts/plugin_runner/merge_data.py
@@ -4,10 +4,11 @@ This class contains methods for merging analysis results from different batches 
 import logging
 import os
 from pathlib import Path
+from typing import List
 
 import pandas as pd
-from typing import List
-from plugin_runner.analyzers import Analyzer, AVAILABLE_ANALYZERS
+
+from plugin_runner.analyzers import AVAILABLE_ANALYZERS, Analyzer
 
 PROJECT_INDEX = "project_index.csv"
 METHOD_INDEX = "method_index.csv"

--- a/scripts/requirements-code-style.txt
+++ b/scripts/requirements-code-style.txt
@@ -1,2 +1,3 @@
 flake8==3.9.2
+flake8-import-order==0.18.1
 wemake_python_styleguide==0.15.3

--- a/scripts/test/plugin_runner/test_create_venv.py
+++ b/scripts/test/plugin_runner/test_create_venv.py
@@ -1,11 +1,12 @@
 import tempfile
 from distutils.version import Version
 from pathlib import Path
+from test.plugin_runner import CREATE_VENV_TEST_DATA_FOLDER
 from typing import Dict, List, Optional, Set
 
 import httpretty
+
 import pkg_resources
-import pytest as pytest
 
 from plugin_runner.create_venv import (
     PYPI_PACKAGE_METADATA_URL,
@@ -18,7 +19,8 @@ from plugin_runner.create_venv import (
     gather_requirements,
     merge_requirements,
 )
-from test.plugin_runner import CREATE_VENV_TEST_DATA_FOLDER
+
+import pytest as pytest
 
 
 @pytest.fixture

--- a/scripts/utils/file_utils.py
+++ b/scripts/utils/file_utils.py
@@ -3,8 +3,7 @@ import os
 import shutil
 from enum import Enum, unique
 from pathlib import Path
-
-from typing import List, Callable
+from typing import Callable, List
 
 
 class Extensions(str, enum.Enum):

--- a/scripts/utils/run_process_utils.py
+++ b/scripts/utils/run_process_utils.py
@@ -1,6 +1,5 @@
 import logging
 import subprocess
-
 from typing import List, Tuple
 
 

--- a/scripts/visualization/diagram.py
+++ b/scripts/visualization/diagram.py
@@ -1,6 +1,7 @@
 from typing import Dict, Union
 
 import pandas as pd
+
 import plotly.express as px
 
 """


### PR DESCRIPTION
**Changes**:
- Added flake8-import-order to check the order of imports instead of flake8-isort, since flake8-import-order has better problem messages.
- Fixed import order.
- Also fixed some incorrect imports that were not fixed during refactoring.