### PR TITLE
Bug fixes and small refactoring

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -14,7 +14,7 @@ jobs:
           sudo apt install python3-pip
           python -m pip install virtualenv
 
-      - name: Cache Python virtual enviroment
+      - name: Cache Python virtual environment
         id: pip-cache
         uses: actions/cache@v2
         with:
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       
-      - name: Cache Python virtual enviroment
+      - name: Cache Python virtual environment
         id: pip-cache
         uses: actions/cache@v2
         with:
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache Python virtual enviroment
+      - name: Cache Python virtual environment
         id: pip-cache
         uses: actions/cache@v2
         with:

--- a/scripts/analysis/clones/clones_features_builder.py
+++ b/scripts/analysis/clones/clones_features_builder.py
@@ -34,8 +34,8 @@ def number_of_clones(method_id: int, clones_graph: nx.Graph, predicates: List[Ed
     if method_id not in clones_graph:
         return 0
 
-    edges = map(lambda method_end_id: clones_graph[method_id][method_end_id], clones_graph[method_id])
-    return sum(map(lambda edge: all(map(lambda predicate: predicate.apply(edge), predicates)), edges))
+    edges = [clones_graph[method_id][method_end_id] for method_end_id in clones_graph[method_id]]
+    return sum(all(predicate.apply(edge) for predicate in predicates) for edge in edges)
 
 
 def add_number_of_projects_features(methods_df: pd.DataFrame, clones_graph: nx.Graph = None) -> None:
@@ -55,6 +55,6 @@ def get_projects_amount(node_start: int, clones_graph: nx.Graph, predicates: Lis
     for node_end in clones_graph[node_start]:
         project_end = clones_graph.nodes[node_end][MethodsColumn.PROJECT_ID.value]
         edge = clones_graph[node_start][node_end]
-        if all(map(lambda predicate: predicate.apply(edge), predicates)):
+        if all(predicate.apply(edge) for predicate in predicates):
             all_projects.add(project_end)
     return len(all_projects)

--- a/scripts/analysis/clones/save_adjacency_list.py
+++ b/scripts/analysis/clones/save_adjacency_list.py
@@ -3,7 +3,7 @@ import logging
 import os
 from typing import Dict
 
-from utils import Extensions
+from utils.file_utils import Extensions
 
 CLOSENESS_NEAR_MISS = 80
 CLOSENESS_EXACT = 100

--- a/scripts/analysis/dependencies/import_directives_analysis.py
+++ b/scripts/analysis/dependencies/import_directives_analysis.py
@@ -97,7 +97,7 @@ def fq_names_groups_to_stats(fq_names_groups: FqNamesGroups) -> FqNamesStats:
 
 
 def fq_names_groups_to_dict(fq_names_groups: FqNamesGroups) -> FqNamesDict:
-    return {group_name: fq_names_to_dict(list(map(lambda fq_name: '.'.join(fq_name.split('.')[1:]), group_members)))
+    return {group_name: fq_names_to_dict(['.'.join(fq_name.split('.')[1:]) for fq_name in group_members])
             for group_name, group_members in fq_names_groups.items()}
 
 

--- a/scripts/analysis/gradle_properties/gradle_properties_analysis.py
+++ b/scripts/analysis/gradle_properties/gradle_properties_analysis.py
@@ -75,7 +75,7 @@ def analyze_properties_key_value_stats(df: pd.DataFrame, path_to_result_dir: str
 def get_gradle_properties(path_to_properties: str, path_to_select_properties: str) -> pd.DataFrame:
     df = pd.read_csv(path_to_properties)
     if path_to_select_properties is not None:
-        selected_properties = list(map(lambda p: p.rstrip(), get_file_lines(path_to_select_properties)))
+        selected_properties = [line.rstrip() for line in get_file_lines(path_to_select_properties)]
         df = df[df[GradlePropertiesColumn.PROPERTY_KEY].apply(lambda x: x in selected_properties)]
     return df
 

--- a/scripts/analysis/utils/python_fq_names/README.md
+++ b/scripts/analysis/utils/python_fq_names/README.md
@@ -19,3 +19,4 @@ Run the [filter_unnecessary_fq_names.py](filter_unnecessary_fq_names.py) with th
 | **&#8209;&#8209;filter&#8209;stdlib&#8209;names** | If specified, Python Standard Library names will be filtered out. |
 | **&#8209;&#8209;filter&#8209;dunder&#8209;names** | If specified, dunder names (names which begin and end with double underscores) will be filtered out. |
 | **&#8209;&#8209;filter&#8209;builtin&#8209;names** | If specified, Python builtin names will be filtered out. |
+| **&#8209;&#8209;noisy&#8209;names** | If specified, the names passed with the argument will be filtered out. By default, the following names are filtered out: "src", "test", "tests", "util", "utils", "config", "configs". If you want no noisy names to be filtered out, do not pass any names along with the arguments. |

--- a/scripts/analysis/utils/python_fq_names/filter_unnecessary_fq_names.py
+++ b/scripts/analysis/utils/python_fq_names/filter_unnecessary_fq_names.py
@@ -388,7 +388,7 @@ def _is_stdlib_name(fq_name: str) -> bool:
     """Check if the FQ name starts with the name of the standard module."""
     # Add a dot at the end of the FQ name and at the end of the module names.
     # This is necessary to correctly identify FQ names that start with the name of the standard library.
-    stdlib_modules_with_dot = list(map(lambda module_name: f'{module_name}.', STDLIB_MODULES))
+    stdlib_modules_with_dot = [f'{module_name}.' for module_name in STDLIB_MODULES]
     fq_name_with_dot = f'{fq_name}.'
 
     return any(fq_name_with_dot.startswith(stdlib_module) for stdlib_module in stdlib_modules_with_dot)
@@ -421,7 +421,7 @@ def _is_builtin_name(fq_name: str) -> bool:
     """Check if the FQ name starts with the Python builtin name."""
     # Add a dot at the end of the FQ name and at the end of the builtin names.
     # This is necessary to correctly identify FQ names that start with the name of builtin.
-    builtins_with_dot = list(map(lambda builtin_name: f'{builtin_name}.', BUILTINS))
+    builtins_with_dot = [f'{builtin_name}.' for builtin_name in BUILTINS]
     fq_name_with_dot = f'{fq_name}.'
 
     return any(fq_name_with_dot.startswith(builtin) for builtin in builtins_with_dot)

--- a/scripts/analysis/utils/python_fq_names/filter_unnecessary_fq_names.py
+++ b/scripts/analysis/utils/python_fq_names/filter_unnecessary_fq_names.py
@@ -477,8 +477,6 @@ def main(
         fq_names = fq_names[~mask]
         print(f'Filtered {mask.values.sum()} builtin names.')
 
-    EnvironmentError
-
     if noisy_names:
         mask = fq_names.apply(lambda row: _is_fq_name_in_list(row[column_name], noisy_names), axis=1)
         fq_names = fq_names[~mask]

--- a/scripts/data_collection/filter_dataset.py
+++ b/scripts/data_collection/filter_dataset.py
@@ -13,7 +13,7 @@ def main():
 
 
 def filter_files(input_dir: str, output_dir: str, extension_list: List[str]):
-    dot_extensions = list(map(lambda s: '.' + s, extension_list))
+    dot_extensions = ['.' + extension for extension in extension_list]
     for root, _dirs, files in os.walk(input_dir):
         for file in files:
             file_abs_path = os.path.join(root, file)
@@ -28,7 +28,7 @@ def filter_files(input_dir: str, output_dir: str, extension_list: List[str]):
 
 
 def allowed_extension(filename: str, extensions_list: List[str]) -> bool:
-    return any(map(lambda x: filename.endswith(x), extensions_list))
+    return any(filename.endswith(extension) for extension in extensions_list)
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/data_collection/git_repo.py
+++ b/scripts/data_collection/git_repo.py
@@ -1,6 +1,6 @@
 import os
 
-from utils import run_in_subprocess
+from utils.run_process_utils import run_in_subprocess
 
 
 class GitRepository:

--- a/scripts/data_collection/github_data/api.py
+++ b/scripts/data_collection/github_data/api.py
@@ -4,7 +4,7 @@ from typing import Optional
 from github import Github
 from github.Repository import Repository
 
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 
 def get_github_token() -> str:

--- a/scripts/data_collection/save_metrics.py
+++ b/scripts/data_collection/save_metrics.py
@@ -20,9 +20,9 @@ from github import Github
 
 import pandas as pd
 
-from urllib3.util.retry import Retry
-
 import schedule
+
+from urllib3.util.retry import Retry
 
 from utils.file_utils import create_directory
 

--- a/scripts/data_collection/save_metrics.py
+++ b/scripts/data_collection/save_metrics.py
@@ -20,7 +20,7 @@ from github import Github
 
 import pandas as pd
 
-from requests.packages.urllib3.util.retry import Retry
+from urllib3.util.retry import Retry
 
 import schedule
 

--- a/scripts/plugin_runner/analyzers.py
+++ b/scripts/plugin_runner/analyzers.py
@@ -16,7 +16,7 @@ class Analyzer:
 
     @staticmethod
     def get_analyzers_names(analyzers: List['Analyzer']) -> List[str]:
-        return list(map(lambda a: a.name, analyzers))
+        return [analyzer.name for analyzer in analyzers]
 
     @staticmethod
     def get_analyzer_by_name(analyzers: List['Analyzer'], name: str) -> 'Analyzer':

--- a/scripts/plugin_runner/batch_processing.py
+++ b/scripts/plugin_runner/batch_processing.py
@@ -90,7 +90,7 @@ def filter_repositories_predicate(use_db: bool) -> Callable[[str], bool]:
     db_conn = DatabaseConn()
     table = RepositoriesTable(db_conn)
     repositories_to_analyse = table.select_repositories_to_analyse()
-    repositories_to_analyse_names = list(map(lambda repo: f'{repo[0]}#{repo[1]}', repositories_to_analyse))
+    repositories_to_analyse_names = [f'{repo[0]}#{repo[1]}' for repo in repositories_to_analyse]
     return lambda path: os.path.basename(path) in repositories_to_analyse_names
 
 

--- a/scripts/plugin_runner/merge_data.py
+++ b/scripts/plugin_runner/merge_data.py
@@ -77,7 +77,6 @@ def move_indexes_line(line: str, project_offset: int, method_offset: int, sep: s
 def move_indexes_file(batch_output_path: str, output_path: str, filename: str, project_offset: int,
                       method_offset: int, sep: str = ','):
     with open(os.path.join(batch_output_path, filename)) as batch_output:
-        lines = list(map(lambda line: move_indexes_line(line, project_offset, method_offset, sep),
-                         batch_output.readlines()))
+        lines = [move_indexes_line(line, project_offset, method_offset, sep) for line in batch_output.readlines()]
     with open(os.path.join(output_path, filename), 'a') as final_output:
         final_output.writelines(lines)

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,5 +1,6 @@
 pandas~=1.2.3
 requests~=2.25.1
+urllib3~=1.26.12
 Pygments~=2.9.0
 networkx~=2.5
 argparse~=1.4.0
@@ -9,4 +10,3 @@ plotly~=5.1.0
 anytree~=2.8.0
 typing~=3.7.4.3
 dacite~=1.6.0
-PyGithub~=1.55

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -10,3 +10,4 @@ plotly~=5.1.0
 anytree~=2.8.0
 typing~=3.7.4.3
 dacite~=1.6.0
+psycopg2~=2.9.3

--- a/scripts/test/utils/python/test_pypi_utils.py
+++ b/scripts/test/utils/python/test_pypi_utils.py
@@ -25,7 +25,6 @@ def _httpretty_fixture():
 
 GET_AVAILABLE_VERSIONS_TEST_DATA = [
     (
-        'numpy',
         """
         {
             "releases": {
@@ -38,7 +37,6 @@ GET_AVAILABLE_VERSIONS_TEST_DATA = [
         set(map(pkg_resources.parse_version, ['1.2.3', '3.4.5', '6.7.8'])),
     ),
     (
-        'numpy',
         """
         {
             "releases": {}
@@ -47,12 +45,10 @@ GET_AVAILABLE_VERSIONS_TEST_DATA = [
         set(),
     ),
     (
-        'numpy',
         'This is not a json.',
         set(),
     ),
     (
-        'numpy',
         """
         {
             "incorrect_key": {
@@ -67,20 +63,19 @@ GET_AVAILABLE_VERSIONS_TEST_DATA = [
 ]
 
 
-@pytest.mark.parametrize(('package_name', 'response_json', 'expected_versions'), GET_AVAILABLE_VERSIONS_TEST_DATA)
+@pytest.mark.parametrize(('response_json', 'expected_versions'), GET_AVAILABLE_VERSIONS_TEST_DATA)
 def test_get_available_versions(
     _httpretty_fixture,
-    package_name: str,
     response_json: str,
     expected_versions: Set[Version],
 ):
     httpretty.register_uri(
         httpretty.GET,
-        PYPI_PACKAGE_METADATA_URL.format(package_name=package_name),
+        PYPI_PACKAGE_METADATA_URL.format(package_name='some_package'),
         body=response_json,
     )
 
-    assert expected_versions == get_available_versions(package_name)
+    assert expected_versions == get_available_versions('some_package')
 
 
 GET_PACKAGE_CLASSIFIERS_TEST_DATA = [


### PR DESCRIPTION
**Changes**:
- Fixed unresolved imports:
  - Replaced `from requests.packages.urllib3.util.retry import Retry` with `from urllib3.util.retry import Retry`, because `requests` no longer vendors `urllib3` as of 2.16.0 (we use version 2.25.1) therefore the package `requests.packages.urllib3` is the same as `urllib3`.
- Updated requirements file:
  - Removed one of the `PyGithub` requirement due to its duplication.
  - Added the `urllib3` requirement.
  - Added the missing `psycopg2` requirement.
- Removed the unnecessary `package_name` field from the `test_get_available_versions` function.
- Fixed a typo in `python_build.yml`.
- Fixed code style issues.
- Fixed `filter_unnecessary_fq_names.py`:
  - Added ability to filter out noisy imports (`src`, `test`, `utils` and etc.)
  - Added new builtins from `builtins.py`