### PR TITLE
Benchmark fix

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -41,12 +41,12 @@ jobs:
           path: ./scripts/venv
           key: ${{ runner.os }}-pip-cache-v4-${{ hashFiles('./scripts/requirements*.txt') }}
       
-#       - name: Update Chromium
-#         run: |
-#           sudo apt purge google-chrome-stable
-#           sudo apt purge chromium-browser
-#           sudo apt install -y chromium-browser
-#           chromium --version
+      - name: Update Chromium
+        run: |
+          sudo apt purge google-chrome-stable
+          sudo apt purge chromium-browser
+          sudo apt install -y chromium-browser
+          chromium --version
       
       - name: Run tests
         run: |

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -41,12 +41,12 @@ jobs:
           path: ./scripts/venv
           key: ${{ runner.os }}-pip-cache-v4-${{ hashFiles('./scripts/requirements*.txt') }}
       
-      - name: Update Chromium
-        run: |
-          sudo apt purge google-chrome-stable
-          sudo apt purge chromium-browser
-          sudo apt install -y chromium-browser
-          chromium --version
+#       - name: Update Chromium
+#         run: |
+#           sudo apt purge google-chrome-stable
+#           sudo apt purge chromium-browser
+#           sudo apt install -y chromium-browser
+#           chromium --version
       
       - name: Run tests
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
         maven("https://packages.jetbrains.team/maven/p/big-code/bigcode")
     }
 
-    val utilitiesProjectVersion = "2.0.2"
+    val utilitiesProjectVersion = "2.0.3"
     val utilitiesProjectId = "org.jetbrains.research"
 
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
         maven("https://packages.jetbrains.team/maven/p/big-code/bigcode")
     }
 
-    val utilitiesProjectVersion = "2.0.4"
+    val utilitiesProjectVersion = "2.0.5"
     val utilitiesProjectId = "org.jetbrains.research"
 
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
         maven("https://packages.jetbrains.team/maven/p/big-code/bigcode")
     }
 
-    val utilitiesProjectVersion = "2.0.3"
+    val utilitiesProjectVersion = "2.0.4"
     val utilitiesProjectId = "org.jetbrains.research"
 
     dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ allprojects {
         maven("https://packages.jetbrains.team/maven/p/big-code/bigcode")
     }
 
-    val utilitiesProjectVersion = "1.1"
+    val utilitiesProjectVersion = "2.0.2"
     val utilitiesProjectId = "org.jetbrains.research"
 
     dependencies {

--- a/python-analysers/src/main/kotlin/org/jetbrains/research/lupa/pythonAnalysis/callExpressions/analysis/CallExpressionsAnalysisExecutor.kt
+++ b/python-analysers/src/main/kotlin/org/jetbrains/research/lupa/pythonAnalysis/callExpressions/analysis/CallExpressionsAnalysisExecutor.kt
@@ -8,6 +8,7 @@ import com.jetbrains.python.psi.PyCallExpression
 import com.jetbrains.python.psi.PyDecorator
 import com.jetbrains.python.psi.resolve.PyResolveContext
 import com.jetbrains.python.psi.types.*
+import com.jetbrains.python.sdk.pythonSdk
 import org.jetbrains.kotlin.utils.addToStdlib.ifNotEmpty
 import org.jetbrains.research.lupa.kotlinAnalysis.AnalysisExecutor
 import org.jetbrains.research.lupa.kotlinAnalysis.ExecutorHelper
@@ -20,6 +21,7 @@ import org.jetbrains.research.lupa.kotlinAnalysis.util.PYTHON_VENV_FOLDER_NAME
 import org.jetbrains.research.lupa.kotlinAnalysis.util.RepositoryOpenerUtil
 import org.jetbrains.research.lupa.kotlinAnalysis.util.python.PyPackageUtil
 import org.jetbrains.research.pluginUtilities.sdk.setSdkToProject
+import org.jetbrains.research.pluginUtilities.sdk.takeDownSdkFromProject
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -79,6 +81,11 @@ class CallExpressionsAnalysisExecutor(
                     else -> PyCallExpressionAnalyzer.analyze(it, analyzerContext)
                 }
             }.toMutableSet()
+        }
+
+        ApplicationManager.getApplication().invokeAndWait {
+            logger.info("Taking down the SDK.")
+            project.pythonSdk?.let { takeDownSdkFromProject(project, it) }
         }
 
         filterLocalFqNames(fqNamesByCategory, packageNames)

--- a/scripts/analysis/utils/python_fq_names/filter_unnecessary_fq_names.py
+++ b/scripts/analysis/utils/python_fq_names/filter_unnecessary_fq_names.py
@@ -435,9 +435,7 @@ def _is_private_name(fq_name: str) -> bool:
     if fq_parts[0] == '_thread':
         return False
 
-    return any(
-        [fq_part.startswith('_') and not __is_dunder_name(fq_part) for fq_part in fq_parts],
-    )
+    return any(fq_part.startswith('_') and not __is_dunder_name(fq_part) for fq_part in fq_parts)
 
 
 def main(

--- a/scripts/benchmark/batching/batcher_benchmark.py
+++ b/scripts/benchmark/batching/batcher_benchmark.py
@@ -198,7 +198,7 @@ def run_benchmark(
             with open(log_file_path, 'w+') as log_file:
                 run_in_subprocess(command, stdout_file=log_file, stderr_file=log_file)
 
-            run_data = read_benchmark_output(metric_file)
+            run_data = read_benchmark_output(Path(metric_file.name))
             logger.info(
                 f'№{i + 1}. '
                 f'Time: {run_data.loc[0, BenchmarkResultColumn.TIME.value]} sec, '

--- a/scripts/benchmark/batching/batcher_benchmark.py
+++ b/scripts/benchmark/batching/batcher_benchmark.py
@@ -207,6 +207,8 @@ def run_benchmark(
 
             benchmark_data.append(run_data)
 
+        run_in_subprocess(['./gradlew', '--stop'])
+
     return pd.concat(benchmark_data)
 
 

--- a/scripts/benchmark/batching/batcher_benchmark.py
+++ b/scripts/benchmark/batching/batcher_benchmark.py
@@ -23,6 +23,7 @@ import argparse
 import json
 import logging
 from enum import Enum
+from io import StringIO
 from pathlib import Path
 
 import pandas as pd
@@ -160,6 +161,18 @@ def wrap_with_benchmark(command: List[str], benchmark_output: Path) -> List[str]
     return wrapper + command
 
 
+def read_benchmark_output(benchmark_output: Path) -> pd.DataFrame:
+    with open(benchmark_output) as file:
+        first_line = file.readline()
+        other_lines = file.readlines()
+
+        if first_line.strip() != f'{BenchmarkResultColumn.TIME.value},{BenchmarkResultColumn.RSS.value}':
+            logger.error(f'Benchmark output contains an error message: "{first_line.strip()}".')
+            return pd.read_csv(StringIO(''.join(other_lines)))
+
+        return pd.read_csv(StringIO(''.join([first_line, *other_lines])))
+
+
 def run_benchmark(
     task_name: str,
     analyser: Analyzer,
@@ -185,7 +198,7 @@ def run_benchmark(
             with open(log_file_path, 'w+') as log_file:
                 run_in_subprocess(command, stdout_file=log_file, stderr_file=log_file)
 
-            run_data = pd.read_csv(metric_file)
+            run_data = read_benchmark_output(metric_file)
             logger.info(
                 f'№{i + 1}. '
                 f'Time: {run_data.loc[0, BenchmarkResultColumn.TIME.value]} sec, '

--- a/scripts/benchmark/sampling/config.py
+++ b/scripts/benchmark/sampling/config.py
@@ -31,7 +31,7 @@ class BinsEstimator(Enum):
 
 SCHEMA = {
     ConfigField.SAMPLE_SIZE.value: {'required': True, 'type': 'integer', 'min': 1},
-    ConfigField.LANGUAGE.value: {'required': True, 'type': 'string', 'allowed': Language.values()},
+    ConfigField.LANGUAGE.value: {'required': True, 'nullable': True, 'type': 'string', 'allowed': Language.values()},
     ConfigField.STRATA.value: {
         'required': True,
         'type': 'dict',

--- a/scripts/benchmark/sampling/config.py
+++ b/scripts/benchmark/sampling/config.py
@@ -31,7 +31,7 @@ class BinsEstimator(Enum):
 
 SCHEMA = {
     ConfigField.SAMPLE_SIZE.value: {'required': True, 'type': 'integer', 'min': 1},
-    ConfigField.LANGUAGE.value: {'required': True, 'nullable': True, 'type': 'string', 'allowed': Language.values()},
+    ConfigField.LANGUAGE.value: {'required': True, 'type': 'string', 'allowed': [*Language.values(), None]},
     ConfigField.STRATA.value: {
         'required': True,
         'type': 'dict',

--- a/scripts/benchmark/sampling/sampling_visualization.py
+++ b/scripts/benchmark/sampling/sampling_visualization.py
@@ -36,7 +36,7 @@ class BinsType(Enum):
 
 
 @st.cache
-def _read_data(dataset: Path, language: Language) -> Optional[pd.DataFrame]:
+def _read_data(dataset: Path, language: Optional[Language]) -> Optional[pd.DataFrame]:
     return read_metrics(dataset, language)
 
 
@@ -49,7 +49,7 @@ def read_data_and_metrics() -> Tuple[pd.DataFrame, List[str]]:
     with right_column:
         language = st.selectbox(
             'Language:',
-            options=Language.values(),
+            options=[*Language.values(), None],
             index=Language.values().index(Language.PYTHON.value),
         )
 
@@ -57,7 +57,7 @@ def read_data_and_metrics() -> Tuple[pd.DataFrame, List[str]]:
     if not metrics:
         st.stop()
 
-    raw_data = _read_data(file_path, Language(language))
+    raw_data = _read_data(file_path, Language.from_value(language))
     if raw_data is None:
         st.error('Metrics not found.')
         st.stop()

--- a/scripts/plugin_runner/batch_processing.py
+++ b/scripts/plugin_runner/batch_processing.py
@@ -129,7 +129,7 @@ def split_into_batches(project_paths: List[Path], batching_config: Dict) -> List
     # then the 'language' and 'batch_constraints' fields are not None either.
     if metric_name is not None:
         projects = {
-            project: read_project_metrics(project, Language(batching_config[ConfigField.LANGUAGE.value]))
+            project: read_project_metrics(project, Language.from_value(batching_config[ConfigField.LANGUAGE.value]))
             for project in project_paths
         }
 

--- a/scripts/plugin_runner/batching_config.py
+++ b/scripts/plugin_runner/batching_config.py
@@ -21,8 +21,7 @@ BATCHING_SCHEMA = {
     ConfigField.LANGUAGE.value: {
         'type': 'string',
         'required': False,
-        'nullable': True,
-        'allowed': Language.values(),
+        'allowed': [*Language.values(), None],
         'dependencies': [ConfigField.METRIC.value, ConfigField.BATCH_CONSTRAINTS.value],
     },
     ConfigField.METRIC.value: {

--- a/scripts/plugin_runner/batching_config.py
+++ b/scripts/plugin_runner/batching_config.py
@@ -21,6 +21,7 @@ BATCHING_SCHEMA = {
     ConfigField.LANGUAGE.value: {
         'type': 'string',
         'required': False,
+        'nullable': True,
         'allowed': Language.values(),
         'dependencies': [ConfigField.METRIC.value, ConfigField.BATCH_CONSTRAINTS.value],
     },

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -12,6 +12,6 @@ typing==3.7.4.3
 dacite==1.6.0
 psycopg2==2.9.3
 cerberus==1.3.4
-streamlit==1.13.0
+streamlit==1.23.1
 pyyaml==6.0
 bin-packing-problem==1.0.0

--- a/scripts/test/benchmark/sampling/test_stratified_sampling.py
+++ b/scripts/test/benchmark/sampling/test_stratified_sampling.py
@@ -29,6 +29,7 @@ READ_PROJECT_METRICS_TEST_DATA = [
         Language.KOTLIN,
         {'number_of_lines': 20, 'number_of_files': 53, 'file_size': 74},
     ),
+    ('project_with_several_languages', None, {'number_of_lines': 62, 'number_of_files': 63, 'file_size': 98}),
     ('project_with_several_languages', Language.UNKNOWN, {}),
 ]
 
@@ -36,7 +37,7 @@ READ_PROJECT_METRICS_TEST_DATA = [
 @pytest.mark.parametrize(('project_name', 'language', 'expected_metrics'), READ_PROJECT_METRICS_TEST_DATA)
 def test_read_project_metrics(
     project_name: str,
-    language: Language,
+    language: Optional[Language],
     expected_metrics: Optional[Dict[str, int]],
 ) -> None:
     dataset_path = PROJECTS_DATA_FOLDER / project_name
@@ -53,6 +54,19 @@ READ_METRICS_TEST_DATA = [
     (
         'dataset_with_python',
         Language.PYTHON,
+        pd.DataFrame.from_dict(
+            {
+                'project': ['project_A', 'project_B'],
+                'number_of_lines': [42, None],
+                'number_of_files': [10, None],
+                'number_of_dependencies': [None, 3],
+                'file_size': [None, 93],
+            },
+        ),
+    ),
+    (
+        'dataset_with_python',
+        None,
         pd.DataFrame.from_dict(
             {
                 'project': ['project_A', 'project_B'],
@@ -90,11 +104,28 @@ READ_METRICS_TEST_DATA = [
             },
         ),
     ),
+    (
+        'dataset_with_several_languages',
+        None,
+        pd.DataFrame.from_dict(
+            {
+                'project': ['project_A', 'project_B'],
+                'number_of_lines': [66, None],
+                'number_of_files': [10, 12],
+                'file_size': [24, 93],
+                'number_of_dependencies': [None, 13],
+            },
+        ),
+    ),
 ]
 
 
 @pytest.mark.parametrize(('dataset_name', 'language', 'expected_metrics'), READ_METRICS_TEST_DATA)
-def test_read_metrics(dataset_name: str, language: Language, expected_metrics: Optional[pd.DataFrame]) -> None:
+def test_read_metrics(
+    dataset_name: str,
+    language: Optional[Language],
+    expected_metrics: Optional[pd.DataFrame],
+) -> None:
     dataset_path = DATASETS_DATA_FOLDER / dataset_name
     assert_df_equals(read_metrics(dataset_path, language), expected_metrics, ['project'])
 

--- a/scripts/utils/language.py
+++ b/scripts/utils/language.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 from enum import Enum, unique
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 
 @unique
@@ -25,6 +25,13 @@ class Language(Enum):
             return Language.UNKNOWN
 
         return _EXTENSIONS_TO_LANGUAGE.get(extension, Language.UNKNOWN)
+
+    @classmethod
+    def from_value(cls, value: str, default: Any = None) -> Any:
+        try:
+            return Language(value)
+        except ValueError:
+            return default
 
     @classmethod
     def values(cls) -> List[str]:


### PR DESCRIPTION
**Changes**:
- Updated plugin-utilities to 2.0.5
- Now the call expression analyzer takes down a virtual environment after an analysis 
- Now the benchmark stops gradlew after the script execution
- Fixed the bug that caused the benchmark to fail when the time output contains an error message
- Added the ability to use the `TOTAL` field during batching and sampling